### PR TITLE
Change reconnection interval

### DIFF
--- a/simple-hangout-bot.py
+++ b/simple-hangout-bot.py
@@ -99,10 +99,7 @@ class SimpleHangoutBot(object):
                     sys.exit(0)
                 except Exception as e:
                     report('Client disconnected: {}'.format(e))
-                    wait = tries * 5
-                    if wait > 300:
-                        wait = 300
-                    time.sleep(wait)
+                    time.sleep(10)
                     report('Connecting again ({})'.format(tries))
 
             report('Exiting!')


### PR DESCRIPTION
If the client disconnects, wait a fixed interval of 10 seconds instead of
using a larger interval at each attempt. That would make sense if the
retry attempt counter was reset to zero after each successful connection
but that's not what it was doing and the reconnection interval was quickly
growing to 5 minutes.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>